### PR TITLE
vimproc: Fix when run on non-NixOS linux distros

### DIFF
--- a/additional-nix-code/vimproc.vim
+++ b/additional-nix-code/vimproc.vim
@@ -1,6 +1,9 @@
     buildInputs = [ which ];
 
     buildPhase = ''
-      sed -i 's/vimproc_mac\.so/vimproc_unix\.so/' autoload/vimproc.vim
+      substituteInPlace autoload/vimproc.vim \
+        --replace vimproc_mac.so vimproc_unix.so \
+        --replace vimproc_linux64.so vimproc_unix.so \
+        --replace vimproc_linux32.so vimproc_unix.so
       make -f make_unix.mak
     '';


### PR DESCRIPTION
Prior to this change, if there exists a /lib_/ld-linux_.so.2 on a
system, vimproc will try to load vimproc_linux64.so or
vimproc_linux32.so instead of vimproc_unix.so, which is what nix
actually builds.

Corresponding nixpkgs pull request: https://github.com/NixOS/nixpkgs/pull/9486
